### PR TITLE
Fix support for torch 2.0

### DIFF
--- a/AudioLoader/speech/speechcommands.py
+++ b/AudioLoader/speech/speechcommands.py
@@ -5,6 +5,7 @@ from typing import Tuple, Optional, Callable, Any
 from torch import Tensor
 import os
 import tqdm
+import torch
 __TORCH_GTE_2_0 = False
 split_version = torch.__version__.split(".")
 major_version = int(split_version[0])

--- a/AudioLoader/speech/timit.py
+++ b/AudioLoader/speech/timit.py
@@ -13,10 +13,18 @@ import multiprocessing as mp
 import warnings
 from distutils.dir_util import copy_tree
 from torchaudio.compliance import kaldi # for downsampling
-from torchaudio.datasets.utils import (
-    download_url,
-    extract_archive,
-)
+__TORCH_GTE_2_0 = False
+split_version = torch.__version__.split(".")
+major_version = int(split_version[0])
+if major_version > 1:
+    __TORCH_GTE_2_0 = True
+    from torchaudio.datasets.utils import _extract_zip as extract_archive
+    from torch.hub import download_url_to_file as download_url
+else:
+    from torchaudio.datasets.utils import (
+        download_url,
+        extract_archive,
+    )
 import hashlib
 import torch.nn.functional as F            
 from AudioLoader.music.utils import check_md5


### PR DESCRIPTION
I believe you missed one of the compatibility imports of `timit.py`. The torch version check in `speechcommands.py` also failed so I added the missing import.