### PR TITLE
Invalid hash arguments to download_url

### DIFF
--- a/AudioLoader/speech/mls.py
+++ b/AudioLoader/speech/mls.py
@@ -153,7 +153,7 @@ class MultilingualLibriSpeech(Dataset):
                     print(f'{download_path+ext_archive} already exists, proceed to extraction...')
                 else:
                     print(f'downloading...')
-                    download_url(url, root, hash_value=checksum, hash_type='md5')
+                    download_url(url, root)
                     
             if decision.lower()=='yes':
                 print(f'extracting...')


### PR DESCRIPTION
Since the import uses a different function for torch 2.0, the arguments changed a bit. The function doesn't accept the checksums as before. I just removed it in this PR for now; this shouldn't be merged directly.

A better solution would probably be to use the new checksum arguments (SHA256) and remove support for torch <2 completely. But that's your decision I guess.